### PR TITLE
Remove unnecessary `clone` on `Span`

### DIFF
--- a/derive/src/from_pest/field.rs
+++ b/derive/src/from_pest/field.rs
@@ -44,9 +44,7 @@ impl ConversionStrategy {
     fn apply(self, member: Member) -> TokenStream {
         let conversion = match self {
             ConversionStrategy::FromPest => quote!(::from_pest::FromPest::from_pest(inner)?),
-            ConversionStrategy::Outer(span, mods) => {
-                with_mods(quote_spanned!(span=>span.clone()), mods)
-            }
+            ConversionStrategy::Outer(span, mods) => with_mods(quote_spanned!(span=>span), mods),
             ConversionStrategy::Inner(span, mods, rule) => {
                 let pair = quote!(inner.next().ok_or(::from_pest::ConversionError::NoMatch)?);
                 let get_span = if let Some(rule) = rule {

--- a/examples/csv.rs
+++ b/examples/csv.rs
@@ -1,10 +1,3 @@
-#![allow(
-    bad_style,
-    dead_code,
-    clippy::clone_on_copy,
-    clippy::upper_case_acronyms
-)]
-
 // Unfortunately, you currently have to import all four of these.
 // We're considering what it would look like to make this redundant,
 // and then you'd only need pest and pest-ast.
@@ -47,12 +40,12 @@ mod ast {
     #[pest_ast(rule(Rule::file))]
     pub struct File {
         pub records: Vec<Record>,
-        eoi: EOI,
+        _eoi: Eoi,
     }
 
     #[derive(Debug, FromPest)]
     #[pest_ast(rule(Rule::EOI))]
-    struct EOI;
+    struct Eoi;
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Hi!

I started using `pest-ast` and I was running into the following lint:

```
warning: using `clone` on type `Span<'_>` which implements the `Copy` trait
   --> src/ast.rs:102:38
    |
102 | ...t_ast(outer(with(span_into_string)))] String);
    |          ^^^^^ help: try removing the `clone` call: `outer`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
```

Personally I think it is desirable to have it on, so I checked out `pest-ast`'s code and noticed that the first element in the `ConversionStrategy::Outer` tuple is always a `Span`, which is `Copy` and thus shouldn't ever need `clone`.

I have not delved super deep in the code, though, so I'm not 100% confident on this statement: have I overlooked something?

I also changed the example slightly, removing the need for allowing lints altogether. Hth!