### PR TITLE
Enable outer and inner attributes on enum with all unit variants.

### DIFF
--- a/derive/src/attributes.rs
+++ b/derive/src/attributes.rs
@@ -32,6 +32,7 @@ pub(crate) enum DeriveAttribute {
     Rule(RuleAttribute),
 }
 
+#[derive(Debug)]
 /// `#[pest_ast(..)]` for fields in `#[derive(FromPest)]`
 pub(crate) enum FieldAttribute {
     /// `outer(with(path::to),*)`
@@ -47,12 +48,14 @@ pub(crate) struct GrammarAttribute {
     pub(crate) lit: LitStr,
 }
 
+#[derive(Debug)]
 pub(crate) struct OuterAttribute {
     pub(crate) outer: kw::outer,
     pub(crate) paren: Paren,
     pub(crate) with: Punctuated<WithAttribute, Token![,]>,
 }
 
+#[derive(Debug)]
 pub(crate) struct InnerAttribute {
     pub(crate) inner: kw::inner,
     pub(crate) paren: Paren,
@@ -61,6 +64,7 @@ pub(crate) struct InnerAttribute {
     pub(crate) with: Punctuated<WithAttribute, Token![,]>,
 }
 
+#[derive(Debug)]
 pub(crate) struct WithAttribute {
     pub(crate) with: kw::with,
     pub(crate) paren: Paren,

--- a/derive/src/from_pest/field.rs
+++ b/derive/src/from_pest/field.rs
@@ -1,3 +1,5 @@
+use syn::Variant;
+
 use {
     proc_macro2::{Span, TokenStream},
     syn::{
@@ -99,7 +101,8 @@ fn with_mods(stream: TokenStream, mods: Vec<Path>) -> TokenStream {
         .fold(stream, |stream, path| quote!(#path(#stream)))
 }
 
-pub fn convert(name: &Path, fields: Fields) -> Result<TokenStream> {
+pub fn enum_convert(name: &Path, variant: &Variant) -> Result<TokenStream> {
+    let fields = variant.fields.clone();
     Ok(match fields {
         Fields::Named(fields) => {
             let fields: Vec<_> = fields
@@ -126,6 +129,44 @@ pub fn convert(name: &Path, fields: Fields) -> Result<TokenStream> {
                 .collect::<Result<_>>()?;
             quote!(#name(#(#fields),*))
         }
-        Fields::Unit => quote!(#name),
+        Fields::Unit => {
+            let attrs = FieldAttribute::from_attributes(variant.attrs.clone())?;
+            let real_name =
+                ConversionStrategy::from_attrs(attrs)?.apply(Member::Unnamed(Index::from(0)));
+            quote!(#real_name)
+        }
+    })
+}
+
+pub fn struct_convert(name: &Path, fields: Fields) -> Result<TokenStream> {
+    Ok(match fields {
+        Fields::Named(fields) => {
+            let fields: Vec<_> = fields
+                .named
+                .into_iter()
+                .map(|field| {
+                    let attrs = FieldAttribute::from_attributes(field.attrs)?;
+                    Ok(ConversionStrategy::from_attrs(attrs)?
+                        .apply(Member::Named(field.ident.unwrap())))
+                })
+                .collect::<Result<_>>()?;
+            quote!(#name{#(#fields,)*})
+        }
+        Fields::Unnamed(fields) => {
+            let fields: Vec<_> = fields
+                .unnamed
+                .into_iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    let attrs = FieldAttribute::from_attributes(field.attrs)?;
+                    Ok(ConversionStrategy::from_attrs(attrs)?
+                        .apply(Member::Unnamed(Index::from(i))))
+                })
+                .collect::<Result<_>>()?;
+            quote!(#name(#(#fields),*))
+        }
+        Fields::Unit => {
+            quote!(#name)
+        }
     })
 }

--- a/derive/src/from_pest/mod.rs
+++ b/derive/src/from_pest/mod.rs
@@ -133,7 +133,7 @@ fn derive_for_struct(
         unimplemented!("Grammar introspection not implemented yet")
     }
 
-    let construct = field::convert(&parse_quote!(#name), fields)?;
+    let construct = field::struct_convert(&parse_quote!(#name), fields)?;
 
     let extraneous = crate::trace(
         quote! { "when converting {}, found extraneous {:?}", stringify!(#name), inner},
@@ -177,8 +177,8 @@ fn derive_for_enum(
     let convert_variants: Vec<TokenStream> = variants
         .into_iter()
         .map(|variant| {
-            let variant_name = variant.ident;
-            let construct_variant = field::convert(&parse_quote!(#name::#variant_name), variant.fields)?;
+            let variant_name = &variant.ident;
+            let construct_variant = field::enum_convert(&parse_quote!(#name::#variant_name), &variant)?;
             let extraneous = crate::trace(quote! {
                 "when converting {}, found extraneous {:?}", stringify!(#name), stringify!(#variant_name)
             });


### PR DESCRIPTION
This is a quick and dirty hack. I was attempting to get the pest-at derive works on my enums with all variants are unit type. The enum is like this:
```rust
MyEnum {
  A,
  B,
  C,
}
```
And the formatted output and input to be parsed are in the same format like: `MyEnum : A`, and it is case-insensitive.
So I wrote my `.pest` grammar as follows: 
```
my_enum = { ^"myenum" ~ ":" ~ my_enum_vars }
my_enum_vars = { ^"A" | ^"B"| ^"C"}
```
To achieve the conversion from `&str` to `MyEnum`, I use my own proc-macro derive crate to generate code like this: 
```rust
impl MyEnum {
    fn from_str(input: &str) -> Self {
        let lowercase = input.to_lowercase();
        match lowercase.as_str() {
            "a" => Self::A,
            "b" => Self::B,
            "c" => Self::C,
        }
}
```
and then I added attributes to each variants first.
```rust
#[pest_ast(inner(
rule(Rule::my_enum_vars),
with(span_to_str),
with(MyEnum::from_str),
with(Option::unwrap)
))]
```
The original `pest-ast` codebase does not apply the conversion on unit variant, as I found in `derive/src/from_pest/field.rs`. The reason is the `convert` function accepts `(name: &Path, fields: Fields)` and `Fields` is not available for unit variant in enum, provided by the dependency `syn` crate. However, one can still access to the attributes macros on unit variants by `variant.attrs`. 
Therefore, I edited the `convert` function in `field.rs` to accept parameter `variant: &Variant` for enum case, and leave the original version to be used for struct case. This makes me pass all the existing tests in `ast` by `cargo test`.

Still, I don't have the time and knowledge to fully test this with more potential error-prone cases. In my current usage, it seems my mod only need and only can recognise one `#[pest_ast]` outer or inner attribute. For my intended purpose this is workable enough, since all variants share the same rule and same method to convert to the enum. However, it could be not powerful enough to handle cases with more customisation needed. Finally, as I have zero experience with the development of `pest` and `pest-ast`, I believe this kind of mod is of low quality. I was also surprised to see why it seems nobody cares about using `pest-ast`, this incredible crate, on enum with unit variants. Hopefully, experienced developers of `pest` can see my efforts and discuss if we can make a better version for this demand. Thank you.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced attribute handling for derive macro
	- Improved field conversion logic for structs and enums
	- Updated conversion methods to support more complex attribute parsing

- **New Features**
	- Added specialized conversion functions for struct and enum fields
	- Introduced more granular attribute processing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->